### PR TITLE
feat: restyle client with ms-dos theme

### DIFF
--- a/client/src/components/AdSlot.jsx
+++ b/client/src/components/AdSlot.jsx
@@ -1,8 +1,10 @@
 export default function AdSlot({ label = 'Ad Space' }) {
   return (
-    <div className="ad-slot">
-      <span>{label}</span>
-      <small style={{ marginTop: '0.5rem', display: 'block', opacity: 0.7 }}>Configure Google AdSense or affiliate embed</small>
+    <div className="ad-slot glass-panel" style={{ padding: '1.5rem' }}>
+      <span>{label.toUpperCase()}</span>
+      <small style={{ marginTop: '0.5rem', display: 'block', opacity: 0.7 }}>
+        Insert your retro banners or ASCII art promos here
+      </small>
     </div>
   );
 }

--- a/client/src/components/AgentCard.jsx
+++ b/client/src/components/AgentCard.jsx
@@ -3,36 +3,42 @@ import RatingStars from './RatingStars.jsx';
 
 export default function AgentCard({ agent }) {
   return (
-    <article className="glass-panel" style={{ padding: '1.4rem', display: 'grid', gap: '1rem' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', justifyContent: 'space-between' }}>
+    <article className="glass-panel agent-card">
+      <div className="agent-card__header">
         <div>
-          <Link to={`/agent/${agent._id}`} style={{ fontSize: '1.2rem', fontWeight: 600, color: 'var(--text-primary)' }}>
+          <Link to={`/agent/${agent._id}`} style={{ fontSize: '1.2rem' }}>
             {agent.title}
           </Link>
-          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem', color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
-            <span>@{agent.owner?.username}</span>
-            <span>•</span>
+          <div className="agent-card__meta">
+            <span>@{agent.owner?.username ?? 'unknown'}</span>
             <span>{new Date(agent.createdAt).toLocaleDateString()}</span>
           </div>
         </div>
         <RatingStars rating={agent.ratingAverage} count={agent.ratingCount} compact />
       </div>
-      {agent.description && <p style={{ color: 'var(--text-secondary)', margin: 0 }}>{agent.description}</p>}
+
+      {agent.description && <p className="dos-notice">{agent.description}</p>}
+
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
-        {agent.tags?.length
-          ? agent.tags.map((tag) => (
-              <span key={tag} className="tag">
-                #{tag}
-              </span>
-            ))
-          : <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>No tags</span>}
+        {agent.tags?.length ? (
+          agent.tags.map((tag) => (
+            <span key={tag} className="tag">
+              #{tag}
+            </span>
+          ))
+        ) : (
+          <span className="dos-notice" style={{ fontSize: '0.85rem' }}>
+            No tags listed
+          </span>
+        )}
       </div>
-      <footer style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
-        <div style={{ display: 'flex', gap: '1rem' }}>
-          <span>?? {agent.views}</span>
-          <span>?? {agent.copyCount}</span>
+
+      <footer className="agent-card__footer">
+        <div className="agent-card__stats">
+          <span>Views: {agent.views ?? 0}</span>
+          <span>Copies: {agent.copyCount ?? 0}</span>
         </div>
-        <Link to={`/agent/${agent._id}`} className="neon-button" style={{ padding: '0.45rem 1.1rem', fontSize: '0.8rem' }}>
+        <Link to={`/agent/${agent._id}`} className="dos-button" style={{ fontSize: '0.85rem', padding: '0.5rem 1.1rem' }}>
           View Details
         </Link>
       </footer>

--- a/client/src/components/CommentList.jsx
+++ b/client/src/components/CommentList.jsx
@@ -2,21 +2,19 @@ import RatingStars from './RatingStars.jsx';
 
 export default function CommentList({ reviews = [] }) {
   if (!reviews.length) {
-    return <p style={{ color: 'var(--text-secondary)', marginTop: '1rem' }}>No feedback yet. Be the first to leave a review.</p>;
+    return <p className="dos-notice" style={{ marginTop: '1rem' }}>No feedback yet. Be the first to leave a review.</p>;
   }
 
   return (
-    <div style={{ display: 'grid', gap: '1rem', marginTop: '1rem' }}>
+    <div className="dos-table" style={{ marginTop: '1rem' }}>
       {reviews.map((review) => (
-        <div key={review._id} className="glass-panel" style={{ padding: '1rem 1.2rem', display: 'grid', gap: '0.5rem' }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <span style={{ fontWeight: 500 }}>{review.user?.username ?? 'Anonymous'}</span>
+        <div key={review._id} className="glass-panel dos-comment">
+          <div className="dos-comment__meta">
+            <span style={{ fontWeight: 600 }}>{review.user?.username ?? 'Anonymous'}</span>
             <RatingStars rating={review.rating} compact />
           </div>
-          {review.comment && <p style={{ margin: 0, color: 'var(--text-secondary)' }}>{review.comment}</p>}
-          <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
-            {new Date(review.createdAt).toLocaleString()}
-          </span>
+          {review.comment && <p className="dos-notice" style={{ margin: 0 }}>{review.comment}</p>}
+          <span className="dos-comment__timestamp">{new Date(review.createdAt).toLocaleString()}</span>
         </div>
       ))}
     </div>

--- a/client/src/components/FeaturedShowcase.jsx
+++ b/client/src/components/FeaturedShowcase.jsx
@@ -5,29 +5,28 @@ export default function FeaturedShowcase({ featured }) {
   const { agent, video } = featured ?? {};
 
   return (
-    <section className="banner" style={{ marginBottom: '2rem' }}>
-      <header>
-        <h2 style={{ margin: 0, fontSize: '1.6rem' }}>Weekly Highlights</h2>
-        <p style={{ margin: '0.3rem 0', color: 'var(--text-secondary)' }}>
-          Curated nuggets for your autonomous agent experiments.
+    <section className="banner dos-section">
+      <header className="dos-section" style={{ margin: 0 }}>
+        <h2 style={{ margin: 0 }}>Weekly Highlights</h2>
+        <p className="dos-notice" style={{ margin: 0 }}>
+          Curated morsels for your autonomous agent experiments.
         </p>
       </header>
-      <div style={{ display: 'grid', gap: '1.5rem', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))' }}>
-        <div className="terminal-panel">
+      <div className="featured-grid">
+        <div className="terminal-panel featured-terminal">
           <div className="terminal-header">
-            <span className="terminal-light" style={{ background: '#ff5f56' }} />
-            <span className="terminal-light" style={{ background: '#ffbd2f' }} />
-            <span className="terminal-light" style={{ background: '#27c93f' }} />
-            <span style={{ marginLeft: '1rem', fontSize: '0.85rem', letterSpacing: '0.08em' }}>agent.md spotlight</span>
+            <span>AGENT.MD SPOTLIGHT</span>
           </div>
-          <div className="terminal-body">
+          <div className="terminal-body" style={{ display: 'grid', gap: '0.8rem' }}>
             {agent ? (
-              <div style={{ display: 'grid', gap: '0.6rem' }}>
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
                   <strong>{agent.title}</strong>
                   <RatingStars rating={agent.ratingAverage} count={agent.ratingCount} compact />
                 </div>
-                <p style={{ margin: 0, color: 'var(--text-secondary)' }}>{agent.description || 'No description provided.'}</p>
+                <p className="dos-notice" style={{ margin: 0 }}>
+                  {agent.description || 'No description provided.'}
+                </p>
                 <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
                   {agent.tags?.map((tag) => (
                     <span key={tag} className="tag">
@@ -35,19 +34,21 @@ export default function FeaturedShowcase({ featured }) {
                     </span>
                   ))}
                 </div>
-                <Link to={`/agent/${agent._id}`} className="neon-button" style={{ justifySelf: 'flex-start' }}>
+                <Link to={`/agent/${agent._id}`} className="dos-button" style={{ justifySelf: 'flex-start' }}>
                   Inspect agent.md
                 </Link>
-              </div>
+              </>
             ) : (
-              <p style={{ color: 'var(--text-secondary)' }}>No agents uploaded yet — upload one to be featured!</p>
+              <p className="dos-notice" style={{ margin: 0 }}>
+                No agents uploaded yet â€” add one to unlock the spotlight.
+              </p>
             )}
           </div>
         </div>
-        <div className="glass-panel" style={{ padding: '1rem', minHeight: '240px' }}>
-          <h3 style={{ marginTop: 0 }}>YouTube Deep Dive</h3>
+        <div className="glass-panel" style={{ padding: '1rem', display: 'grid', gap: '1rem' }}>
+          <h3 style={{ margin: 0 }}>Video Deep Dive</h3>
           {video ? (
-            <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, borderRadius: '14px', overflow: 'hidden' }}>
+            <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', border: '2px solid var(--accent)' }}>
               <iframe
                 src={video.embedUrl}
                 title="YouTube video of the week"
@@ -57,8 +58,8 @@ export default function FeaturedShowcase({ featured }) {
               />
             </div>
           ) : (
-            <p style={{ color: 'var(--text-secondary)' }}>
-              Add a list of YouTube video IDs in `YOUTUBE_VIDEO_IDS` to spotlight a weekly tutorial.
+            <p className="dos-notice" style={{ margin: 0 }}>
+              Add YouTube IDs to <code>YOUTUBE_VIDEO_IDS</code> to showcase tutorials.
             </p>
           )}
         </div>

--- a/client/src/components/LoadingState.jsx
+++ b/client/src/components/LoadingState.jsx
@@ -1,18 +1,8 @@
-export default function LoadingState({ label = 'Loading…' }) {
+export default function LoadingState({ label = 'Loading' }) {
   return (
-    <div style={{ textAlign: 'center', padding: '2rem', color: 'var(--text-secondary)' }}>
-      <div
-        style={{
-          width: '48px',
-          height: '48px',
-          border: '4px solid rgba(0, 255, 213, 0.1)',
-          borderTopColor: 'var(--accent)',
-          borderRadius: '50%',
-          margin: '0 auto 1rem',
-          animation: 'spin 1s linear infinite'
-        }}
-      />
-      <span>{label}</span>
+    <div className="dos-loading">
+      <span>{label.toUpperCase()}</span>
+      <span className="dos-loading__cursor">â–Œ</span>
     </div>
   );
 }

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -10,40 +10,41 @@ export default function Navbar() {
     navigate('/login');
   };
 
-  return (
-    <header className="glass-panel" style={{ margin: '1rem auto', width: 'min(100%, var(--max-width))' }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '1rem 1.5rem' }}>
-        <Link to="/" style={{ display: 'flex', alignItems: 'center', gap: '0.8rem' }}>
-          <span style={{ fontSize: '1.4rem', fontWeight: 600, color: 'var(--accent)' }}>AgentBazaar</span>
-          <span className="tag">v1</span>
-        </Link>
+  const navLinkClass = ({ isActive }) => `dos-link${isActive ? ' dos-link--active' : ''}`;
+  const navButtonClass = ({ isActive }) => `dos-button${isActive ? ' dos-link--active' : ''}`;
 
-        <nav style={{ display: 'flex', alignItems: 'center', gap: '1.2rem' }}>
-          <NavLink to="/library" className="neon-button" style={{ padding: '0.55rem 1.1rem', fontSize: '0.85rem' }}>
-            Library
-          </NavLink>
-          <NavLink to="/featured" className="neon-button" style={{ padding: '0.55rem 1.1rem', fontSize: '0.85rem' }}>
-            Highlights
-          </NavLink>
-          {isAuthenticated ? (
-            <>
-              <NavLink to="/upload" className="neon-button" style={{ padding: '0.55rem 1.1rem', fontSize: '0.85rem' }}>
-                Upload
-              </NavLink>
-              <NavLink to="/dashboard" style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
-                {user?.username}
-              </NavLink>
-              <button onClick={handleLogout} className="neon-button" style={{ background: 'rgba(255, 85, 119, 0.12)', borderColor: 'rgba(255, 85, 119, 0.45)', fontSize: '0.85rem' }}>
-                Logout
-              </button>
-            </>
-          ) : (
-            <NavLink to="/login" className="neon-button" style={{ padding: '0.55rem 1.1rem', fontSize: '0.85rem' }}>
-              Login / Join
+  return (
+    <header className="glass-panel dos-navbar">
+      <Link to="/" className="dos-brand">
+        <span>AgentBazaar</span>
+        <span className="dos-badge">v1</span>
+      </Link>
+
+      <nav className="dos-nav">
+        <NavLink to="/library" className={navLinkClass}>
+          Library
+        </NavLink>
+        <NavLink to="/featured" className={navLinkClass}>
+          Highlights
+        </NavLink>
+        {isAuthenticated ? (
+          <>
+            <NavLink to="/upload" className={navButtonClass}>
+              Upload
             </NavLink>
-          )}
-        </nav>
-      </div>
+            <NavLink to="/dashboard" className={navLinkClass}>
+              @{user?.username ?? 'user'}
+            </NavLink>
+            <button type="button" onClick={handleLogout} className="dos-button dos-button--danger">
+              Logout
+            </button>
+          </>
+        ) : (
+          <NavLink to="/login" className={navButtonClass}>
+            Login / Join
+          </NavLink>
+        )}
+      </nav>
     </header>
   );
 }

--- a/client/src/components/RatingStars.jsx
+++ b/client/src/components/RatingStars.jsx
@@ -2,10 +2,11 @@ const STAR_COUNT = 5;
 
 export default function RatingStars({ rating = 0, count = 0, onRate, compact = false }) {
   const stars = Array.from({ length: STAR_COUNT }, (_, index) => index + 1);
+  const wrapperClass = `dos-rating${compact ? ' dos-rating--compact' : ''}`;
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
-      <div style={{ display: 'flex', gap: '0.2rem' }}>
+    <div className={wrapperClass}>
+      <div className="dos-rating__stars">
         {stars.map((value) => {
           const filled = value <= Math.round(rating);
           return (
@@ -14,21 +15,16 @@ export default function RatingStars({ rating = 0, count = 0, onRate, compact = f
               type="button"
               onClick={() => onRate?.(value)}
               disabled={!onRate}
-              style={{
-                background: 'transparent',
-                border: 'none',
-                cursor: onRate ? 'pointer' : 'default',
-                color: filled ? 'var(--accent)' : 'rgba(255, 255, 255, 0.25)',
-                fontSize: compact ? '1rem' : '1.2rem'
-              }}
+              className={`dos-rating__button${filled ? ' is-filled' : ''}`}
+              aria-label={`Rate ${value}`}
             >
-              ?
+              {filled ? '█' : '░'}
             </button>
           );
         })}
       </div>
       {!compact && (
-        <span style={{ color: 'var(--text-secondary)', fontSize: '0.9rem' }}>
+        <span className="dos-notice" style={{ fontSize: '0.9rem' }}>
           {rating?.toFixed ? rating.toFixed(1) : rating} ({count})
         </span>
       )}

--- a/client/src/pages/AgentDetailPage.jsx
+++ b/client/src/pages/AgentDetailPage.jsx
@@ -63,50 +63,57 @@ export default function AgentDetailPage() {
         }
         return [newReview, ...current];
       });
-      setAgent((prev) => (prev ? { ...prev, ratingAverage: response.data.rating.ratingAverage, ratingCount: response.data.rating.ratingCount } : prev));
+      setAgent((prev) =>
+        prev
+          ? {
+              ...prev,
+              ratingAverage: response.data.rating.ratingAverage,
+              ratingCount: response.data.rating.ratingCount
+            }
+          : prev
+      );
     } catch (error) {
       setStatus(error.response?.data?.message ?? 'Failed to submit feedback.');
     }
   };
 
   if (!agent) {
-    return <LoadingState label="Retrieving agent dossier..." />;
+    return <LoadingState label="Retrieving agent dossier" />;
   }
 
   return (
-    <main style={{ display: 'grid', gap: '2rem' }}>
-      <section className="glass-panel" style={{ padding: '2rem', display: 'grid', gap: '1rem' }}>
+    <main>
+      <section className="glass-panel dos-section">
         <header style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', justifyContent: 'space-between', alignItems: 'center' }}>
           <div>
             <h1 style={{ marginBottom: '0.5rem' }}>{agent.title}</h1>
-            <div style={{ color: 'var(--text-secondary)', fontSize: '0.9rem', display: 'flex', gap: '0.6rem', flexWrap: 'wrap' }}>
+            <div className="dos-notice" style={{ display: 'flex', gap: '0.6rem', flexWrap: 'wrap' }}>
               <span>By @{agent.owner?.username ?? 'unknown'}</span>
-              <span>•</span>
               <span>{new Date(agent.createdAt).toLocaleString()}</span>
             </div>
           </div>
-          <button onClick={copyToClipboard} className="neon-button">
+          <button type="button" onClick={copyToClipboard} className="dos-button">
             Copy agent.md
           </button>
         </header>
         <RatingStars rating={agent.ratingAverage} count={agent.ratingCount} />
         <div className="terminal-panel">
           <div className="terminal-header">
-            <span className="terminal-light" style={{ background: '#27ffa9' }} />
-            <span className="terminal-light" style={{ background: '#ff5f56' }} />
-            <span style={{ marginLeft: '0.6rem' }}>agent.md</span>
+            <span>AGENT.MD</span>
           </div>
           <pre className="terminal-body" style={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word', maxHeight: '520px', overflowY: 'auto' }}>
             {agent.content}
           </pre>
         </div>
-        {status && <span style={{ color: status.includes('fail') ? 'var(--danger)' : 'var(--success)' }}>{status}</span>}
+        {status && (
+          <span style={{ color: status.includes('fail') ? 'var(--danger)' : 'var(--success)' }}>{status}</span>
+        )}
       </section>
 
-      <section>
+      <section className="dos-section">
         <h2>Community feedback</h2>
         {isAuthenticated ? (
-          <form onSubmit={submitReview} className="glass-panel" style={{ padding: '1.5rem', display: 'grid', gap: '1rem', marginBottom: '1.5rem' }}>
+          <form onSubmit={submitReview} className="glass-panel dos-section" style={{ marginBottom: '1.5rem' }}>
             <div>
               <span style={{ display: 'block', marginBottom: '0.4rem' }}>Your rating</span>
               <RatingStars rating={userRating} onRate={setUserRating} />
@@ -117,12 +124,12 @@ export default function AgentDetailPage() {
               onChange={(event) => setComment(event.target.value)}
               rows={4}
             />
-            <button type="submit" className="neon-button" style={{ justifySelf: 'flex-start' }}>
+            <button type="submit" className="dos-button" style={{ justifySelf: 'flex-start' }}>
               Submit feedback
             </button>
           </form>
         ) : (
-          <p style={{ color: 'var(--text-secondary)' }}>Login to rate and discuss this agent.</p>
+          <p className="dos-notice">Login to rate and discuss this agent.</p>
         )}
 
         <CommentList reviews={reviews} />

--- a/client/src/pages/AuthPage.jsx
+++ b/client/src/pages/AuthPage.jsx
@@ -35,41 +35,45 @@ export default function AuthPage() {
 
   return (
     <main>
-      <section className="glass-panel" style={{ padding: '2.2rem', display: 'grid', gap: '1.6rem', maxWidth: '460px', margin: '0 auto' }}>
+      <section className="glass-panel dos-section" style={{ maxWidth: '460px', margin: '0 auto' }}>
         <header style={{ textAlign: 'center' }}>
-          <h1>{isRegister ? 'Join AgentBazaar' : 'Welcome back, Operator'}</h1>
-          <p style={{ color: 'var(--text-secondary)' }}>
-            {isRegister ? 'Create an account to upload and curate agent.md playbooks.' : 'Sign in to manage your agents and community feedback.'}
+          <h1>{isRegister ? 'Join AgentBazaar' : 'Operator Login'}</h1>
+          <p className="dos-notice" style={{ margin: 0 }}>
+            {isRegister
+              ? 'Create an account to upload and curate agent.md playbooks.'
+              : 'Sign in to manage your agents and community feedback.'}
           </p>
         </header>
-        <form onSubmit={handleSubmit} style={{ display: 'grid', gap: '1.1rem' }}>
+        <form onSubmit={handleSubmit} className="dos-section">
           {isRegister && (
-            <label style={{ display: 'grid', gap: '0.5rem' }}>
+            <label className="dos-section" style={{ gap: '0.4rem' }}>
               <span>Username</span>
               <input name="username" value={form.username} onChange={handleChange} required={isRegister} />
             </label>
           )}
-          <label style={{ display: 'grid', gap: '0.5rem' }}>
+          <label className="dos-section" style={{ gap: '0.4rem' }}>
             <span>Email</span>
             <input type="email" name="email" value={form.email} onChange={handleChange} required />
           </label>
-          <label style={{ display: 'grid', gap: '0.5rem' }}>
+          <label className="dos-section" style={{ gap: '0.4rem' }}>
             <span>Password</span>
             <input type="password" name="password" value={form.password} onChange={handleChange} minLength={6} required />
           </label>
           {error && <span style={{ color: 'var(--danger)' }}>{error}</span>}
-          <button type="submit" className="neon-button" style={{ justifyContent: 'center' }}>
+          <button type="submit" className="dos-button">
             {isRegister ? 'Create account' : 'Login'}
           </button>
         </form>
         <button
+          type="button"
           onClick={() => {
             setMode(isRegister ? 'login' : 'register');
             setError('');
           }}
-          style={{ background: 'transparent', border: 'none', color: 'var(--accent)', cursor: 'pointer' }}
+          className="dos-link"
+          style={{ border: '1px solid var(--accent)', alignSelf: 'center' }}
         >
-          {isRegister ? 'Have an account? Login instead.' : "Need an account? Register now."}
+          {isRegister ? 'Have an account? Login instead.' : 'Need an account? Register now.'}
         </button>
       </section>
     </main>

--- a/client/src/pages/DashboardPage.jsx
+++ b/client/src/pages/DashboardPage.jsx
@@ -30,32 +30,32 @@ export default function DashboardPage() {
   }
 
   if (loading || !data) {
-    return <LoadingState label="Crunching metrics..." />;
+    return <LoadingState label="Crunching metrics" />;
   }
 
   const { summary, files } = data;
 
   return (
-    <main style={{ display: 'grid', gap: '2rem' }}>
-      <section className="banner">
+    <main>
+      <section className="banner dos-section">
         <div>
           <h1 style={{ margin: 0 }}>Welcome back, @{user?.username}</h1>
-          <p style={{ margin: '0.3rem 0', color: 'var(--text-secondary)' }}>
+          <p className="dos-notice" style={{ margin: '0.3rem 0' }}>
             Track how your agents perform across the bazaar.
           </p>
         </div>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '1rem' }}>
+        <div className="dos-metric-grid">
           <Metric label="Uploads" value={summary.totalFiles} />
           <Metric label="Total Views" value={summary.totalViews} />
           <Metric label="Copies" value={summary.totalCopies} />
-          <Metric label="Avg Rating" value={summary.averageRating || '—'} />
+          <Metric label="Avg Rating" value={summary.averageRating || ''} />
         </div>
       </section>
 
-      <section style={{ display: 'grid', gap: '1.2rem' }}>
+      <section className="glass-panel dos-section">
         <header>
           <h2 style={{ marginBottom: '0.3rem' }}>Your agents</h2>
-          <p style={{ margin: 0, color: 'var(--text-secondary)' }}>Sorted by most recent uploads.</p>
+          <p className="dos-notice" style={{ margin: 0 }}>Sorted by most recent uploads.</p>
         </header>
         <div className="card-grid">
           {files.map((agent) => (
@@ -69,11 +69,9 @@ export default function DashboardPage() {
 
 function Metric({ label, value }) {
   return (
-    <div className="glass-panel" style={{ padding: '1.4rem', display: 'grid', gap: '0.4rem' }}>
-      <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', letterSpacing: '0.08em', textTransform: 'uppercase' }}>
-        {label}
-      </span>
-      <strong style={{ fontSize: '1.6rem' }}>{value}</strong>
+    <div className="glass-panel dos-metric">
+      <span className="dos-metric__label">{label}</span>
+      <strong className="dos-metric__value">{value}</strong>
     </div>
   );
 }

--- a/client/src/pages/FeaturedPage.jsx
+++ b/client/src/pages/FeaturedPage.jsx
@@ -28,16 +28,18 @@ export default function FeaturedPage() {
   }, []);
 
   if (loading) {
-    return <LoadingState label="Picking highlights..." />;
+    return <LoadingState label="Picking highlights" />;
   }
 
   return (
     <main>
       <FeaturedShowcase featured={featured} />
-      <section style={{ display: 'grid', gap: '1.5rem' }}>
+      <section className="glass-panel dos-section">
         <header>
           <h2 style={{ marginBottom: '0.3rem' }}>Hall of Fame</h2>
-          <p style={{ margin: 0, color: 'var(--text-secondary)' }}>Best-rated agent.md files of the week.</p>
+          <p className="dos-notice" style={{ margin: 0 }}>
+            Best-rated agent.md files of the week.
+          </p>
         </header>
         <div className="card-grid">
           {topRated.map((agent) => (

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -29,18 +29,18 @@ export default function HomePage() {
   }, []);
 
   if (loading) {
-    return <LoadingState label="Spinning up the bazaar..." />;
+    return <LoadingState label="Spinning up the bazaar" />;
   }
 
   return (
     <main>
       <FeaturedShowcase featured={featured} />
-      <section style={{ marginBottom: '2.5rem', display: 'grid', gap: '1.5rem' }}>
-        <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <div>
-            <h2 style={{ marginBottom: '0.3rem' }}>Popular this week</h2>
-            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>Top-downloaded agent.md files from the community.</p>
-          </div>
+      <section className="glass-panel dos-section">
+        <header>
+          <h2 style={{ marginBottom: '0.3rem' }}>Popular this week</h2>
+          <p className="dos-notice" style={{ margin: 0 }}>
+            Top-downloaded agent.md files from the community.
+          </p>
         </header>
         <div className="card-grid">
           {popular.map((agent) => (

--- a/client/src/pages/LibraryPage.jsx
+++ b/client/src/pages/LibraryPage.jsx
@@ -50,10 +50,10 @@ export default function LibraryPage() {
 
   return (
     <main>
-      <section className="glass-panel" style={{ padding: '1.8rem', marginBottom: '2rem', display: 'grid', gap: '1rem' }}>
+      <section className="glass-panel dos-section">
         <header>
           <h1 style={{ margin: 0 }}>Agent Library</h1>
-          <p style={{ margin: '0.4rem 0', color: 'var(--text-secondary)' }}>
+          <p className="dos-notice" style={{ margin: '0.4rem 0' }}>
             Browse, search, and remix agent playbooks contributed by the community.
           </p>
         </header>
@@ -63,20 +63,21 @@ export default function LibraryPage() {
           value={query}
           onChange={(event) => setQuery(event.target.value)}
         />
-        {message && <span style={{ color: 'var(--success)' }}>{message}</span>}
+        {message && <span style={{ color: message.includes('fail') ? 'var(--danger)' : 'var(--success)' }}>{message}</span>}
       </section>
 
       {loading ? (
-        <LoadingState label="Indexing agents..." />
+        <LoadingState label="Indexing agents" />
       ) : (
         <div className="card-grid">
           {agents.map((agent) => (
             <div key={agent._id} style={{ position: 'relative' }}>
               <AgentCard agent={agent} />
               <button
-                className="neon-button"
-                style={{ position: 'absolute', top: '1.4rem', right: '1.4rem', padding: '0.35rem 0.9rem', fontSize: '0.75rem' }}
+                className="dos-button"
+                style={{ position: 'absolute', top: '1.4rem', right: '1.4rem', fontSize: '0.75rem', padding: '0.4rem 0.9rem' }}
                 onClick={() => handleCopy(agent._id)}
+                type="button"
               >
                 Copy agent.md
               </button>
@@ -85,7 +86,7 @@ export default function LibraryPage() {
         </div>
       )}
 
-      <div style={{ marginTop: '2.5rem' }}>
+      <div>
         <AdSlot label="Sponsored Tools" />
       </div>
     </main>

--- a/client/src/pages/UploadPage.jsx
+++ b/client/src/pages/UploadPage.jsx
@@ -59,42 +59,43 @@ export default function UploadPage() {
 
   return (
     <main>
-      <section className="glass-panel" style={{ padding: '2rem', display: 'grid', gap: '1.5rem' }}>
+      <section className="glass-panel dos-section">
         <header>
           <h1 style={{ margin: 0 }}>Upload agent.md</h1>
-          <p style={{ margin: '0.4rem 0', color: 'var(--text-secondary)' }}>
+          <p className="dos-notice" style={{ margin: '0.4rem 0' }}>
             Share your orchestrations and empower the community. Markdown only.
           </p>
         </header>
-        <form onSubmit={handleSubmit} style={{ display: 'grid', gap: '1.2rem' }}>
-          <label style={{ display: 'grid', gap: '0.6rem' }}>
+        <form onSubmit={handleSubmit} className="dos-section">
+          <label className="dos-section" style={{ gap: '0.4rem' }}>
             <span>Title</span>
             <input name="title" value={form.title} onChange={handleChange} required maxLength={120} />
           </label>
-          <label style={{ display: 'grid', gap: '0.6rem' }}>
+          <label className="dos-section" style={{ gap: '0.4rem' }}>
             <span>Description</span>
             <textarea name="description" value={form.description} onChange={handleChange} maxLength={400} rows={3} />
           </label>
-          <label style={{ display: 'grid', gap: '0.6rem' }}>
+          <label className="dos-section" style={{ gap: '0.4rem' }}>
             <span>Tags (comma separated)</span>
             <input name="tags" value={form.tags} onChange={handleChange} placeholder="search, retrieval, langchain" />
           </label>
-          <label style={{ display: 'grid', gap: '0.6rem' }}>
+          <label className="dos-section" style={{ gap: '0.4rem' }}>
             <span>agent.md file</span>
             <input type="file" accept=".md,text/markdown" onChange={handleFile} required />
           </label>
-          <button type="submit" className="neon-button" style={{ justifySelf: 'flex-start' }}>
+          <button type="submit" className="dos-button" style={{ justifySelf: 'flex-start' }}>
             Upload to Bazaar
           </button>
-          {status && <span style={{ color: status.includes('fail') ? 'var(--danger)' : 'var(--success)' }}>{status}</span>}
+          {status && (
+            <span style={{ color: status.includes('fail') ? 'var(--danger)' : 'var(--success)' }}>{status}</span>
+          )}
         </form>
       </section>
 
       {preview && (
         <section className="terminal-panel" style={{ marginTop: '2rem' }}>
           <div className="terminal-header">
-            <span className="terminal-light" style={{ background: '#00ffd5' }} />
-            <span style={{ marginLeft: '0.6rem' }}>Preview</span>
+            <span>PREVIEW</span>
           </div>
           <pre className="terminal-body" style={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word' }}>
             {preview}

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -1,15 +1,15 @@
 :root {
   color-scheme: dark;
-  --bg-color: #0b1120;
-  --bg-elevated: #111a2e;
-  --accent: #00ffd5;
-  --accent-soft: rgba(0, 255, 213, 0.1);
-  --text-primary: #f6f8ff;
-  --text-secondary: #8ea0ce;
-  --danger: #ff5577;
-  --success: #27ffa9;
-  --max-width: 1200px;
-  font-family: 'Fira Code', 'Segoe UI', monospace;
+  --bg-color: #040404;
+  --bg-elevated: #020805;
+  --accent: #2bff72;
+  --accent-soft: rgba(43, 255, 114, 0.18);
+  --text-primary: #d6ffd6;
+  --text-secondary: #7fff9e;
+  --danger: #ff5252;
+  --success: #2bff72;
+  --max-width: 1100px;
+  font-family: 'VT323', 'Lucida Console', 'Courier New', monospace;
 }
 
 * {
@@ -18,40 +18,74 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top left, rgba(0, 255, 213, 0.15), transparent 45%),
-    radial-gradient(circle at bottom right, rgba(61, 90, 254, 0.15), transparent 40%),
-    var(--bg-color);
-  color: var(--text-primary);
   min-height: 100vh;
+  background-color: var(--bg-color);
+  background-image: radial-gradient(circle at 20% -10%, rgba(43, 255, 114, 0.12), transparent 55%),
+    radial-gradient(circle at 80% 110%, rgba(43, 255, 114, 0.06), transparent 60%),
+    repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.12) 0px, rgba(0, 0, 0, 0.12) 2px, rgba(43, 255, 114, 0.04) 4px,
+      rgba(0, 0, 0, 0.12) 6px);
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+  text-shadow: 0 0 6px rgba(43, 255, 114, 0.4);
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(180deg, rgba(0, 0, 0, 0) 0px, rgba(0, 0, 0, 0) 2px, rgba(0, 0, 0, 0.25) 4px);
+  opacity: 0.25;
+  mix-blend-mode: screen;
+  z-index: 0;
 }
 
 a {
-  color: inherit;
+  color: var(--text-primary);
   text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent);
 }
 
 button {
   font-family: inherit;
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border: 2px solid var(--accent);
+  padding: 0.6rem 1.2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 input,
 textarea,
 select {
   font-family: inherit;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #000;
+  border: 2px solid var(--accent);
   color: var(--text-primary);
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
-  transition: border 0.2s ease, box-shadow 0.2s ease;
+  padding: 0.6rem 0.9rem;
+  resize: vertical;
 }
 
 input:focus,
 textarea:focus,
 select:focus {
   outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 2px var(--accent-soft);
+  box-shadow: 0 0 0 3px rgba(43, 255, 114, 0.15);
+}
+
+::placeholder {
+  color: rgba(214, 255, 214, 0.6);
 }
 
 ::-webkit-scrollbar {
@@ -59,56 +93,77 @@ select:focus {
 }
 
 ::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.05);
+  background: #050505;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(0, 255, 213, 0.4);
-  border-radius: 6px;
+  background: var(--accent);
 }
 
 main {
   width: min(100%, var(--max-width));
-  margin: 0 auto;
-  padding: 1.5rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem 3rem;
+  display: grid;
+  gap: 2rem;
+  position: relative;
+  z-index: 1;
 }
 
 .glass-panel {
-  background: rgba(9, 17, 35, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 16px;
-  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(18px);
+  background: rgba(0, 0, 0, 0.75);
+  border: 2px solid var(--accent);
+  border-radius: 0;
+  box-shadow: 0 0 0 2px rgba(43, 255, 114, 0.2), 0 0 24px rgba(43, 255, 114, 0.15);
+  position: relative;
+  z-index: 1;
 }
 
 .tag {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.15rem 0.7rem;
-  border-radius: 999px;
-  background: rgba(0, 255, 213, 0.12);
+  gap: 0.25rem;
+  padding: 0.1rem 0.6rem;
+  border: 1px solid var(--accent);
+  background: rgba(43, 255, 114, 0.08);
   color: var(--accent);
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
 
+.dos-button,
 .neon-button {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.6rem;
-  border-radius: 12px;
-  padding: 0.85rem 1.4rem;
-  border: 1px solid rgba(0, 255, 213, 0.4);
-  background: linear-gradient(120deg, rgba(0, 255, 213, 0.12), rgba(50, 100, 255, 0.08));
+  border-radius: 0;
+  padding: 0.65rem 1.2rem;
+  border: 2px solid var(--accent);
+  background: rgba(0, 0, 0, 0.8);
   color: var(--text-primary);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  box-shadow: inset 0 0 0 1px rgba(43, 255, 114, 0.25);
 }
 
+.dos-button:hover,
 .neon-button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 25px rgba(0, 255, 213, 0.25);
+  background: var(--accent);
+  color: #021802;
+  box-shadow: 0 0 12px rgba(43, 255, 114, 0.6);
+}
+
+.dos-button--danger {
+  border-color: var(--danger);
+  box-shadow: inset 0 0 0 1px rgba(255, 82, 82, 0.3);
+}
+
+.dos-button--danger:hover {
+  background: var(--danger);
+  color: #050505;
+  box-shadow: 0 0 12px rgba(255, 82, 82, 0.6);
 }
 
 .card-grid {
@@ -123,66 +178,271 @@ main {
 }
 
 .terminal-panel {
-  background: rgba(8, 14, 28, 0.95);
-  border-radius: 18px;
-  border: 1px solid rgba(0, 255, 213, 0.18);
-  box-shadow: 0 0 30px rgba(0, 255, 213, 0.1);
+  background: #000;
+  border: 2px solid var(--accent);
+  box-shadow: 0 0 18px rgba(43, 255, 114, 0.18);
   overflow: hidden;
 }
 
 .terminal-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.4rem;
-  padding: 0.75rem 1rem;
-  background: linear-gradient(45deg, rgba(0, 255, 213, 0.18), rgba(44, 82, 240, 0.18));
-}
-
-.terminal-light {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.35);
+  padding: 0.6rem 0.9rem;
+  border-bottom: 2px solid var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(43, 255, 114, 0.08);
 }
 
 .terminal-body {
-  padding: 1rem 1.5rem;
-  font-size: 0.95rem;
-  line-height: 1.6;
+  padding: 1rem 1.2rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--text-primary);
 }
 
 .banner {
   display: grid;
-  gap: 1rem;
+  gap: 1.4rem;
   padding: 1.5rem;
-  border-radius: 20px;
-  border: 1px solid rgba(0, 255, 213, 0.18);
-  background: linear-gradient(120deg, rgba(8, 20, 45, 0.9), rgba(5, 12, 28, 0.85));
-  position: relative;
-  overflow: hidden;
-}
-
-.banner::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 20% 20%, rgba(0, 255, 213, 0.15), transparent 55%);
-  pointer-events: none;
+  border: 2px double var(--accent);
+  background: rgba(0, 0, 0, 0.85);
+  box-shadow: 0 0 26px rgba(43, 255, 114, 0.18);
 }
 
 .ad-slot {
   min-height: 120px;
-  border: 1px dashed rgba(255, 255, 255, 0.2);
-  border-radius: 16px;
+  border: 2px dashed var(--accent);
   display: grid;
   place-content: center;
   color: var(--text-secondary);
-  font-size: 0.8rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.dos-navbar {
+  width: min(100%, var(--max-width));
+  margin: 1.5rem auto 0;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.dos-brand {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.8rem;
+  font-size: 1.6rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
+
+.dos-badge {
+  font-size: 0.9rem;
+  padding: 0.1rem 0.5rem;
+  border: 1px solid var(--accent);
+  background: rgba(43, 255, 114, 0.08);
+}
+
+.dos-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.dos-link {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid transparent;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.dos-link:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.dos-link--active {
+  border-color: var(--accent);
+  background: rgba(43, 255, 114, 0.12);
+}
+
+.agent-card {
+  padding: 1.4rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.agent-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.agent-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.agent-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.agent-card__stats {
+  display: flex;
+  gap: 1rem;
+}
+
+.featured-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .featured-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+}
+
+.featured-terminal {
+  min-height: 100%;
+  display: grid;
+}
+
+.dos-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.dos-notice {
+  color: var(--text-secondary);
+}
+
+.dos-loading {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.dos-loading__cursor {
+  display: inline-block;
+  margin-left: 0.4rem;
+  animation: blink 1s steps(2, jump-none) infinite;
+}
+
+@keyframes blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
+.dos-rating {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.dos-rating__stars {
+  display: flex;
+  gap: 0.2rem;
+}
+
+.dos-rating__button {
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: rgba(214, 255, 214, 0.4);
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.dos-rating__button:hover,
+.dos-rating__button:focus {
+  color: var(--accent);
+}
+
+.dos-rating__button.is-filled {
+  color: var(--accent);
+}
+
+.dos-rating--compact .dos-rating__button {
+  font-size: 1rem;
+}
+
+.dos-table {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.dos-comment {
+  padding: 1rem 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.dos-comment__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dos-comment__timestamp {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.dos-metric-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 700px) {
+  .dos-metric-grid {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+
+.dos-metric {
+  padding: 1.2rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.dos-metric__label {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.dos-metric__value {
+  font-size: 1.6rem;
 }


### PR DESCRIPTION
## Summary
- restyle the client shell with a monochrome MS-DOS aesthetic and CRT-inspired global theming
- update navigation, cards, forms, and terminal panels to match the retro look across key pages
- refresh interactive components like ratings, loading state, and comments to use the new styling patterns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e23f7742d883288bbc6ead9fb7058d