### PR TITLE
feat: add modern design selector

### DIFF
--- a/client/src/components/DesignSelector.jsx
+++ b/client/src/components/DesignSelector.jsx
@@ -1,0 +1,28 @@
+import { useId } from 'react';
+import { useDesign } from '../context/DesignContext.jsx';
+
+export default function DesignSelector() {
+  const { design, setDesign, designs } = useDesign();
+  const labelId = useId();
+
+  const handleChange = (event) => {
+    const nextDesign = event.target.value;
+
+    if (designs.some((option) => option.id === nextDesign)) {
+      setDesign(nextDesign);
+    }
+  };
+
+  return (
+    <label className="design-selector" htmlFor={labelId}>
+      <span className="design-selector__label">Design</span>
+      <select id={labelId} className="design-selector__select" value={design} onChange={handleChange}>
+        {designs.map((option) => (
+          <option key={option.id} value={option.id}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,5 +1,6 @@
 import { Link, NavLink, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext.jsx';
+import DesignSelector from './DesignSelector.jsx';
 
 export default function Navbar() {
   const { isAuthenticated, logout, user } = useAuth();
@@ -21,29 +22,34 @@ export default function Navbar() {
       </Link>
 
       <nav className="dos-nav">
-        <NavLink to="/library" className={navLinkClass}>
-          Library
-        </NavLink>
-        <NavLink to="/featured" className={navLinkClass}>
-          Highlights
-        </NavLink>
-        {isAuthenticated ? (
-          <>
-            <NavLink to="/upload" className={navButtonClass}>
-              Upload
-            </NavLink>
-            <NavLink to="/dashboard" className={navLinkClass}>
-              @{user?.username ?? 'user'}
-            </NavLink>
-            <button type="button" onClick={handleLogout} className="dos-button dos-button--danger">
-              Logout
-            </button>
-          </>
-        ) : (
-          <NavLink to="/login" className={navButtonClass}>
-            Login / Join
+        <div className="dos-nav__group">
+          <NavLink to="/library" className={navLinkClass}>
+            Library
           </NavLink>
-        )}
+          <NavLink to="/featured" className={navLinkClass}>
+            Highlights
+          </NavLink>
+        </div>
+        <div className="dos-nav__group dos-nav__group--actions">
+          {isAuthenticated ? (
+            <>
+              <NavLink to="/upload" className={navButtonClass}>
+                Upload
+              </NavLink>
+              <NavLink to="/dashboard" className={navLinkClass}>
+                @{user?.username ?? 'user'}
+              </NavLink>
+              <button type="button" onClick={handleLogout} className="dos-button dos-button--danger">
+                Logout
+              </button>
+            </>
+          ) : (
+            <NavLink to="/login" className={navButtonClass}>
+              Login / Join
+            </NavLink>
+          )}
+          <DesignSelector />
+        </div>
       </nav>
     </header>
   );

--- a/client/src/context/DesignContext.jsx
+++ b/client/src/context/DesignContext.jsx
@@ -1,0 +1,56 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const DEFAULT_DESIGN = 'retro';
+const STORAGE_KEY = 'agentbazaar:design';
+
+const designOptions = [
+  { id: 'retro', label: 'Retro Terminal' },
+  { id: 'modern', label: 'Modern Dev' },
+];
+
+const DesignContext = createContext(undefined);
+
+export function DesignProvider({ children }) {
+  const [design, setDesign] = useState(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_DESIGN;
+    }
+
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+
+    if (stored && designOptions.some((option) => option.id === stored)) {
+      return stored;
+    }
+
+    return DEFAULT_DESIGN;
+  });
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = design;
+
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, design);
+    }
+  }, [design]);
+
+  const value = useMemo(
+    () => ({
+      design,
+      setDesign,
+      designs: designOptions,
+    }),
+    [design],
+  );
+
+  return <DesignContext.Provider value={value}>{children}</DesignContext.Provider>;
+}
+
+export function useDesign() {
+  const context = useContext(DesignContext);
+
+  if (!context) {
+    throw new Error('useDesign must be used within a DesignProvider');
+  }
+
+  return context;
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,13 +3,16 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import { AuthProvider } from './context/AuthContext.jsx';
+import { DesignProvider } from './context/DesignContext.jsx';
 import './styles/global.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
       <AuthProvider>
-        <App />
+        <DesignProvider>
+          <App />
+        </DesignProvider>
       </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -223,6 +223,198 @@ main {
   letter-spacing: 0.18em;
 }
 
+[data-theme='modern'] {
+  color-scheme: dark;
+  --bg-color: #0b1220;
+  --bg-elevated: #101a2b;
+  --accent: #5eead4;
+  --accent-soft: rgba(94, 234, 212, 0.18);
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5f5;
+  --danger: #f87171;
+  --success: #5eead4;
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+}
+
+[data-theme='modern'] body {
+  background-color: var(--bg-color);
+  background-image: radial-gradient(circle at 15% 10%, rgba(94, 234, 212, 0.25), transparent 45%),
+    radial-gradient(circle at 85% 120%, rgba(14, 165, 233, 0.2), transparent 55%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.65), rgba(11, 18, 32, 0.95));
+  color: var(--text-primary);
+  letter-spacing: 0.01em;
+  text-shadow: none;
+}
+
+[data-theme='modern'] body::before {
+  content: none;
+}
+
+[data-theme='modern'] .glass-panel {
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(94, 234, 212, 0.3);
+  border-radius: 18px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
+}
+
+[data-theme='modern'] .dos-navbar {
+  padding: 1.2rem 1.5rem;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.5);
+}
+
+[data-theme='modern'] .dos-brand {
+  gap: 0.6rem;
+  font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+[data-theme='modern'] .dos-badge {
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  border-color: rgba(94, 234, 212, 0.4);
+  background: rgba(94, 234, 212, 0.16);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+}
+
+[data-theme='modern'] .dos-nav {
+  gap: 1.2rem;
+}
+
+[data-theme='modern'] .dos-nav__group--actions {
+  gap: 1rem;
+}
+
+[data-theme='modern'] .dos-link {
+  border-radius: 999px;
+  padding: 0.5rem 1.05rem;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: rgba(226, 232, 240, 0.9);
+  border: 1px solid transparent;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+[data-theme='modern'] .dos-link:hover {
+  color: var(--text-primary);
+  background: rgba(148, 163, 184, 0.16);
+  border-color: transparent;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.2);
+}
+
+[data-theme='modern'] .dos-link--active {
+  background: rgba(94, 234, 212, 0.2);
+  color: var(--text-primary);
+  border-color: rgba(94, 234, 212, 0.35);
+  box-shadow: 0 10px 28px rgba(94, 234, 212, 0.25);
+}
+
+[data-theme='modern'] .dos-button,
+[data-theme='modern'] .neon-button {
+  border-radius: 999px;
+  border: 1px solid rgba(94, 234, 212, 0.6);
+  background: linear-gradient(135deg, rgba(94, 234, 212, 0.22), rgba(15, 23, 42, 0.78));
+  color: var(--text-primary);
+  text-transform: none;
+  letter-spacing: 0.02em;
+  font-weight: 600;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.45);
+}
+
+[data-theme='modern'] .dos-button:hover,
+[data-theme='modern'] .neon-button:hover {
+  background: rgba(94, 234, 212, 0.85);
+  color: #0f172a;
+  box-shadow: 0 24px 50px rgba(94, 234, 212, 0.35);
+}
+
+[data-theme='modern'] .dos-button--danger {
+  border-color: rgba(248, 113, 113, 0.6);
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.3), rgba(15, 23, 42, 0.78));
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.45);
+}
+
+[data-theme='modern'] .dos-button--danger:hover {
+  background: rgba(248, 113, 113, 0.9);
+  color: #0f172a;
+}
+
+[data-theme='modern'] input,
+[data-theme='modern'] textarea,
+[data-theme='modern'] select {
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 12px;
+  padding: 0.65rem 0.9rem;
+  letter-spacing: 0.01em;
+}
+
+[data-theme='modern'] input:focus,
+[data-theme='modern'] textarea:focus,
+[data-theme='modern'] select:focus {
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.25);
+  border-color: rgba(94, 234, 212, 0.6);
+}
+
+[data-theme='modern'] .terminal-panel {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(94, 234, 212, 0.3);
+  border-radius: 18px;
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.5);
+}
+
+[data-theme='modern'] .terminal-header {
+  background: rgba(94, 234, 212, 0.12);
+  border-bottom: 1px solid rgba(94, 234, 212, 0.3);
+  letter-spacing: 0.04em;
+}
+
+[data-theme='modern'] .banner {
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.45);
+}
+
+[data-theme='modern'] .ad-slot {
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  color: rgba(148, 163, 184, 0.8);
+  letter-spacing: 0.12em;
+}
+
+[data-theme='modern'] .agent-card__meta,
+[data-theme='modern'] .agent-card__footer {
+  color: rgba(203, 213, 225, 0.85);
+}
+
+[data-theme='modern'] .design-selector {
+  background: rgba(148, 163, 184, 0.14);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  font-weight: 500;
+}
+
+[data-theme='modern'] .design-selector__label {
+  font-size: 0.82rem;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+[data-theme='modern'] .design-selector__select {
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.9);
+  color: var(--text-primary);
+  padding: 0.35rem 0.95rem;
+  text-transform: none;
+  letter-spacing: 0.01em;
+  box-shadow: inset 0 0 0 1px rgba(94, 234, 212, 0.22);
+}
+
 .dos-navbar {
   width: min(100%, var(--max-width));
   margin: 1.5rem auto 0;
@@ -256,6 +448,34 @@ main {
   flex-wrap: wrap;
 }
 
+.dos-nav__group {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.dos-nav__group--actions {
+  margin-left: auto;
+}
+
+@media (max-width: 720px) {
+  .dos-nav {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .dos-nav__group {
+    justify-content: flex-start;
+  }
+
+  .dos-nav__group--actions {
+    margin-left: 0;
+    justify-content: flex-start;
+    gap: 0.75rem;
+  }
+}
+
 .dos-link {
   display: inline-flex;
   align-items: center;
@@ -273,6 +493,33 @@ main {
 .dos-link--active {
   border-color: var(--accent);
   background: rgba(43, 255, 114, 0.12);
+}
+
+.design-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid rgba(43, 255, 114, 0.35);
+  background: rgba(0, 0, 0, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.design-selector__label {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.design-selector__select {
+  appearance: none;
+  background: #000;
+  border: 1px solid var(--accent);
+  color: var(--text-primary);
+  padding: 0.25rem 0.75rem 0.3rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: pointer;
 }
 
 .agent-card {


### PR DESCRIPTION
## Summary
- add a design context and selector UI so users can switch between layouts
- wrap the app with the new provider and surface the selector in the navbar
- implement a modern programmer visual theme alongside the existing retro styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2884a14548328a2d3e4cab9938f84