### PR TITLE
feat: add workflow.sg leaderboard ascii promo

### DIFF
--- a/client/src/components/AdSlot.jsx
+++ b/client/src/components/AdSlot.jsx
@@ -1,10 +1,16 @@
-export default function AdSlot({ label = 'Ad Space' }) {
+export default function AdSlot({ label = 'Ad Space', children }) {
+  const hasCustomContent = Boolean(children);
+
   return (
     <div className="ad-slot glass-panel" style={{ padding: '1.5rem' }}>
-      <span>{label.toUpperCase()}</span>
-      <small style={{ marginTop: '0.5rem', display: 'block', opacity: 0.7 }}>
-        Insert your retro banners or ASCII art promos here
-      </small>
+      <span className="ad-slot-label">{label.toUpperCase()}</span>
+      {hasCustomContent ? (
+        <div className="ad-slot-content">{children}</div>
+      ) : (
+        <small style={{ display: 'block', opacity: 0.7, textTransform: 'uppercase', letterSpacing: '0.18em' }}>
+          Insert your retro banners or ASCII art promos here
+        </small>
+      )}
     </div>
   );
 }

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -89,7 +89,20 @@ export default function HomePage() {
           ))}
         </div>
       </section>
-      <AdSlot label="728x90 Leaderboard" />
+      <AdSlot label="728x90 Leaderboard">
+        <a href="https://www.workflow.sg" target="_blank" rel="noopener noreferrer" aria-label="Need to automate your workflow?">
+          <pre>
+            {String.raw`
+ __        __   _                          _                  
+ \ \      / /__| | ___ ___  _ __ ___   ___| |_ _   _ _ __ ___ 
+  \ \ /\ / / _ \ |/ __/ _ \| '_ \  _ \ / _ \ __| | | | '__/ _ \
+   \ V  V /  __/ | (_| (_) | | | | | |  __/ |_| |_| | | |  __/
+    \_/\_/ \___|_|\___\___/|_| |_| |_|\___|\__|\__,_|_|  \___|
+`}
+          </pre>
+          <span className="ad-tagline">Need to automate your workflow?</span>
+        </a>
+      </AdSlot>
     </main>
   );
 }

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -375,12 +375,54 @@ main {
 .ad-slot {
   min-height: 120px;
   border: 2px dashed var(--accent);
-  display: grid;
-  place-content: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
   color: var(--text-secondary);
+  text-align: center;
+}
+
+.ad-slot-label {
   font-size: 0.9rem;
-  text-transform: uppercase;
   letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.ad-slot-content {
+  font-family: 'IBM Plex Mono', 'Fira Code', 'SFMono-Regular', ui-monospace, 'Roboto Mono', monospace;
+  font-size: 0.95rem;
+  line-height: 1.15;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.ad-slot-content pre {
+  margin: 0;
+  font: inherit;
+  white-space: pre;
+}
+
+.ad-slot-content a {
+  color: inherit;
+  text-decoration: none;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.ad-slot-content a:hover,
+.ad-slot-content a:focus {
+  text-decoration: underline;
+  text-decoration-style: wavy;
+}
+
+.ad-slot-content .ad-tagline {
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
 }
 
 [data-theme='modern'] {
@@ -541,6 +583,9 @@ main {
 [data-theme='modern'] .ad-slot {
   border: 1px dashed rgba(148, 163, 184, 0.4);
   color: rgba(148, 163, 184, 0.8);
+}
+
+[data-theme='modern'] .ad-slot-label {
   letter-spacing: 0.12em;
 }
 


### PR DESCRIPTION
## Summary
- allow AdSlot to render custom promo content while keeping default messaging for empty slots
- style the ad slot container for monospace ascii creative layouts
- embed a workflow.sg ascii leaderboard banner linking to the automation site

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e470108674832898433b2cef9a364c